### PR TITLE
Make the Android support a noop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,17 @@ if(target MATCHES "darwin|ios")
     PRIVATE
       THREAD_STATS_APPLE=1
   )
-elseif(target MATCHES "linux|android")
+elseif(target MATCHES "linux")
   target_compile_definitions(
     ${thread_stats_bare}
     PRIVATE
       THREAD_STATS_LINUX=1
+  )
+elseif(target MATCHES "android")
+  target_compile_definitions(
+    ${thread_stats_bare}
+    PRIVATE
+      THREAD_STATS_ANDROID=1
   )
 endif()
 
@@ -51,10 +57,16 @@ if(target MATCHES "darwin|ios")
     PRIVATE
       THREAD_STATS_APPLE=1
   )
-elseif(target MATCHES "linux|android")
+elseif(target MATCHES "linux")
   target_compile_definitions(
     ${thread_stats_node}
     PRIVATE
       THREAD_STATS_LINUX=1
+  )
+elseif(target MATCHES "android")
+  target_compile_definitions(
+    ${thread_stats_node}
+    PRIVATE
+      THREAD_STATS_ANDROID=1
   )
 endif()

--- a/binding.c
+++ b/binding.c
@@ -21,6 +21,8 @@ thread_stats (js_env_t *env, js_callback_info_t *info) {
   err = thread_stats__apple(stats, &len);
 #elif THREAD_STATS_LINUX
   err = thread_stats__linux(stats, &len);
+#elif THREAD_STATS_ANDROID
+  len = err = 0;
 #else
   err = -1;
 #endif


### PR DESCRIPTION
Due to the OS design, always return an empty array on Android.